### PR TITLE
Fix ungettable escaped key bug

### DIFF
--- a/lib/mock-localstorage.js
+++ b/lib/mock-localstorage.js
@@ -20,7 +20,7 @@ function createNewMock() {
     Object.defineProperty(oStorage, "getItem", {
         value: function (sKey) {
             var key = sKey + "";
-            return (oStorage[key] === null) ? "null" : oStorage[key]
+            return (oStorage[escape(key)] === null) ? "null" : oStorage[escape(key)];
         },
         writable: false,
         configurable: false,

--- a/test/getItem-test.js
+++ b/test/getItem-test.js
@@ -16,9 +16,10 @@ describe("getItem", function () {
         localStorage.setItem("undefined", "foo");
         localStorage.setItem("null", "bar");
         localStorage.setItem("", "baz");
+        localStorage.setItem("a:b", "qux");
     });
     it("1", function () {
-        assert.equal(localStorage.length, 3);
+        assert.equal(localStorage.length, 4);
     }, "All 3 items should be added.");
     it("2", function () {
         assert.equal(localStorage["unknown"], undefined, "localStorage['unknown']")
@@ -34,5 +35,6 @@ describe("getItem", function () {
         assert.equal(localStorage.getItem(undefined), "foo", "localStorage.getItem(undefined)")
         assert.equal(localStorage.getItem(null), "bar", "localStorage.getItem(null)")
         assert.equal(localStorage.getItem(""), "baz", "localStorage.getItem('')")
+        assert.equal(localStorage.getItem("a:b"), "qux", "localStorage.getItem('a:b')")
     }, "getItem should be correct")
 });


### PR DESCRIPTION
I got this problem:
```
 var localStorage = new MockLocalStorage();
localStorage.setItem('a:b', 'foo');
localStorage.getItem('a:b');  // -> undefined
```