### PR TITLE
Fix clear bug

### DIFF
--- a/lib/mock-localstorage.js
+++ b/lib/mock-localstorage.js
@@ -60,7 +60,7 @@ function createNewMock() {
         value: function () {
             Object.keys(oStorage).forEach(function (key) {
 
-                delete oStorage[escape(key)];
+                delete oStorage[key];
             });
         },
         writable: false,

--- a/test/clear-test.js
+++ b/test/clear-test.js
@@ -1,0 +1,26 @@
+/**
+ * Created by kjirou on 2015/04/08.
+ * LICENSE : MIT
+ */
+"use strict";
+var assert = require("power-assert");
+var MockLocalStorage = require("../");
+describe("clear", function () {
+    var localStorage;
+    before(function () {
+        localStorage = new MockLocalStorage();
+    });
+    // clear
+    it("clear", function () {
+        assert.equal(localStorage.length, 0);
+        localStorage.setItem("name", "user1");
+        assert.equal(localStorage.getItem("name"), "user1");
+        localStorage.setItem("escapedkey:name", "user2");
+        assert.equal(localStorage.getItem("escapedkey:name"), "user2");
+        assert.equal(localStorage.length, 2);
+        localStorage.clear()
+        assert.equal(localStorage.length, 0);
+        assert.equal(localStorage.getItem("name"), null, "localStorage.getItem('name')")
+        assert.equal(localStorage.getItem("escapedkey:name"), null, "localStorage.getItem('escapedkey:name')")
+    });
+});


### PR DESCRIPTION
There was such a problem:
```
let localStorage = new MockLocalStorage();
localStorage.setItem('foo', 1);
localStorage.setItem('a:b', 2);
localStorage.clear();
localStorage.getItem('foo');  // -> null
localStorage.getItem('a:b');  // -> 2
```