### PR TITLE
The key method returns unescaped string now

### DIFF
--- a/lib/mock-localstorage.js
+++ b/lib/mock-localstorage.js
@@ -11,7 +11,8 @@ function createNewMock() {
     };
     Object.defineProperty(oStorage, "key", {
         value: function (nKeyId) {
-            return Object.keys(oStorage)[nKeyId];
+            var key = Object.keys(oStorage)[nKeyId];
+            return (typeof key === "undefined") ? null : unescape(key);
         },
         writable: false,
         configurable: false,

--- a/test/key-test.js
+++ b/test/key-test.js
@@ -1,0 +1,30 @@
+/**
+ * Created by kjirou on 2015/04/08.
+ * LICENSE : MIT
+ */
+"use strict";
+var assert = require("power-assert");
+var MockLocalStorage = require("../");
+// key
+describe("key", function () {
+    var localStorage;
+    before(function () {
+        localStorage = new MockLocalStorage();
+    });
+    it("0", function () {
+        localStorage.clear();
+        localStorage.setItem("foo", 1);
+        localStorage.setItem("escaped:key", 1);
+        var keys = [];
+        for (var i = 0; i < localStorage.length; i++) {
+          keys.push(localStorage.key(i));
+        }
+        keys.sort();
+        assert.deepEqual(keys, ["escaped:key", "foo"]);
+    });
+    it("1", function () {
+        localStorage.clear();
+        assert.equal(localStorage.length, 0);
+        assert.strictEqual(localStorage.key(1), null);
+    }, 'key should return null if it does not exist');
+});


### PR DESCRIPTION
（すみません、日本語で）

- https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Storage#Compatibility を見ると、非エスケープの値を返しているのでそうしました
- 値がない場合は null を返すようにしました。仕様は調べてませんが、手元の Chrome や Firefox の挙動がそうでした

お手数です。