### PR TITLE
Make getItem return null if not found instead of undefined. Change so…

### DIFF
--- a/lib/mock-localstorage.js
+++ b/lib/mock-localstorage.js
@@ -20,8 +20,13 @@ function createNewMock() {
     });
     Object.defineProperty(oStorage, "getItem", {
         value: function (sKey) {
-            var key = sKey + "";
-            return (oStorage[escape(key)] === null) ? "null" : oStorage[escape(key)];
+            var key = escape(sKey + "");
+            if (oStorage[key] === undefined) {
+                return null;
+            } else if (oStorage[key] === null) {
+                return 'null';
+            }
+            return oStorage[key];
         },
         writable: false,
         configurable: false,

--- a/test/clear-test.js
+++ b/test/clear-test.js
@@ -20,7 +20,7 @@ describe("clear", function () {
         assert.equal(localStorage.length, 2);
         localStorage.clear()
         assert.equal(localStorage.length, 0);
-        assert.equal(localStorage.getItem("name"), null, "localStorage.getItem('name')")
-        assert.equal(localStorage.getItem("escapedkey:name"), null, "localStorage.getItem('escapedkey:name')")
+        assert.strictEqual(localStorage.getItem("name"), null, "localStorage.getItem('name')")
+        assert.strictEqual(localStorage.getItem("escapedkey:name"), null, "localStorage.getItem('escapedkey:name')")
     });
 });

--- a/test/getItem-test.js
+++ b/test/getItem-test.js
@@ -22,7 +22,8 @@ describe("getItem", function () {
         assert.equal(localStorage.length, 4);
     }, "All 3 items should be added.");
     it("2", function () {
-        assert.equal(localStorage["unknown"], undefined, "localStorage['unknown']")
+        // Array style access should return undefined if not found, the same as real localstorage.
+        assert.strictEqual(localStorage["unknown"], undefined, "localStorage['unknown']")
         assert.equal(localStorage["undefined"], "foo", "localStorage['undefined']")
         assert.equal(localStorage["null"], "bar", "localStorage['null']")
         assert.equal(localStorage[undefined], "foo", "localStorage[undefined]")
@@ -30,6 +31,8 @@ describe("getItem", function () {
         assert.equal(localStorage[""], "baz", "localStorage['']")
     }, "array access should be correct");
     it("3", function () {
+        // getItem style access should return null if not found, the same as real localstorage.
+        assert.strictEqual(localStorage.getItem("unknown"), null, "localStorage.getItem('undefined')")
         assert.equal(localStorage.getItem("undefined"), "foo", "localStorage.getItem('undefined')")
         assert.equal(localStorage.getItem("null"), "bar", "localStorage.getItem('null')")
         assert.equal(localStorage.getItem(undefined), "foo", "localStorage.getItem(undefined)")

--- a/test/removeItem-test.js
+++ b/test/removeItem-test.js
@@ -17,6 +17,6 @@ describe("removeItem", function () {
         assert.equal(localStorage.getItem("name"), "user1");
         localStorage.removeItem("name");
         localStorage.removeItem("unknown");
-        assert.equal(localStorage.getItem("name"), null, "localStorage.getItem('name')")
+        assert.strictEqual(localStorage.getItem("name"), null, "localStorage.getItem('name')")
     });
 });


### PR DESCRIPTION
…me tests to use strictEqual to ensure this is the case. Fixes #5